### PR TITLE
Fixes to enable production deploy

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -10,7 +10,7 @@ import setupGitHubLogin from './auth';
 import { User, Post, Comment } from './models';
 
 dotenv.config();
-mongoose.connect('mongodb://localhost/db');
+mongoose.connect(process.env.NODE_ENV === 'production' ? process.env.MONGODB_URI : 'mongodb://localhost/db');
 
 const app = express();
 

--- a/api/package.json
+++ b/api/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "new-api",
+  "name": "pairhub-api",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "nodemon --exec babel-node index.js"
+    "dev": "nodemon --exec babel-node index.js",
+    "start": "NODE_ENV=production babel-node index.js"
   },
   "author": "",
   "license": "ISC",
@@ -35,8 +36,6 @@
     "passport-github": "^1.1.0"
   },
   "babel": {
-    "presets": [
-      "env"
-    ]
+    "presets": ["env"]
   }
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "dev": "node lib/server.js",
-    "build": "next build",
+    "build": "NODE_ENV=production next build",
     "start": "NODE_ENV=production node lib/server.js"
   },
   "repository": {


### PR DESCRIPTION
Closes #3. PairHub is now deployed at https://pairhub.io using Now and Mongo Atlas.